### PR TITLE
Fix typo in clusterversion

### DIFF
--- a/content/clusterversion/_index.md
+++ b/content/clusterversion/_index.md
@@ -65,7 +65,7 @@ cat <<EOF >version-patch.yaml
   value:
   - kind: Deployment
     group: apps
-    name: cluster-network-operator
+    name: network-operator
     namespace: openshift-network-operator
     unmanaged: true
 EOF
@@ -80,7 +80,7 @@ cat <<EOF >version-patch.yaml
   value:
   - kind: Deployment
     group: apps
-    name: cluster-network-operator
+    name: network-operator
     namespace: openshift-network-operator
     unmanaged: true
 EOF


### PR DESCRIPTION
The name of the deployment is network-operator, not cluster-network-operator